### PR TITLE
Update flashcards_dashboard and upload_page routes

### DIFF
--- a/app/components/Deck.tsx
+++ b/app/components/Deck.tsx
@@ -25,7 +25,7 @@ export default function Deck({ cards }: DeckProps) {
         showCount={true}
         frontContentStyle={{
           backgroundColor: "white",
-          color: "yellow",
+          color: "black",
           display: "flex",
           justifyContent: "center",
           alignItems: "center",
@@ -34,9 +34,13 @@ export default function Deck({ cards }: DeckProps) {
         backContentStyle={{
           backgroundColor: "white",
           color: "black",
+          display: 'flex',
           justifyContent: "center",
           alignItems: "center",
           padding: "10px",
+        }}
+        frontCardStyle={{
+          padding: '10px',
         }}
       />
     </div>

--- a/app/components/DropZone.tsx
+++ b/app/components/DropZone.tsx
@@ -7,6 +7,8 @@ import { FlashcardArray } from "react-quizlet-flashcard";
 import { storage } from "../../firebase";
 import Deck from "./Deck";
 const DropZone = () => {
+
+  //The different states for handling file, cards, and the upload progress
   const [uploadProgress, setUploadProgress] = useState(0);
   const [flashcards, setFlashcards] = useState([]);
   const [downloadURL, setDownloadURL] = useState("");
@@ -14,15 +16,18 @@ const DropZone = () => {
     Array<{ id: number; frontHTML: string; backHTML: string }>
   >([]);
   const [file, setFile] = useState<File>();
+  const [isuploaded, setIsUploaded] = useState(false);
   const { getRootProps, getInputProps } = useDropzone({
     accept: { "application/pdf": [".pdf"] },
     maxFiles: 1,
     onDrop: (acceptedFiles) => {
       if (acceptedFiles[0]) {
         setFile(acceptedFiles[0]);
+        setIsUploaded(true);
       }
     },
   });
+  
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -81,7 +86,7 @@ const DropZone = () => {
   return (
     <div className="flex flex-col items-center justify-center h-screen gap-y-4">
       <div className="p-2 bg-white rounded-xl">
-        <form onSubmit={handleSubmit}>
+        <form onSubmit={handleSubmit} className="flex flex-col justify-center">
           <div
             {...getRootProps({
               className:
@@ -92,12 +97,13 @@ const DropZone = () => {
             <>
               <Inbox className="w-10 h-10 text-blue-500 text-center" />
             </>
-            <p className="mt-2 text-sm text-slate-400">
-              Drag 'n' drop some files here, or click to select files
-            </p>
+            {isuploaded ? (<p className="mt-2 text-sm text-slate-400">{file?.name} has been uploaded, click 'Generate' to create your flashcards</p>) : (<p className="mt-2 text-sm text-slate-400">
+                                 Drag 'n' drop some files here, or click to select files
+                               </p>)}
+            
           </div>
-          <button className="text-black" type="submit">
-            Save File
+          <button className=" mt-2 px-6 py-3 text-sm sm:text-base rounded-full bg-white text-black hover:bg-fuchsia-700 hover:text-white transition-colors" type="submit">
+            Generate
           </button>
         </form>
 

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -27,9 +27,8 @@ const Header = () => {
                 <a href='#pricing' className="px-6 py-3 text-sm sm:text-base rounded-full bg-white text-black hover:bg-fuchsia-700 hover:text-white transition-colors">
                    Try it for free!
                 </a>
-                    </div>
+                    */}
 
-            
                 </div>
             </div>
         </header>

--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -5,5 +5,11 @@ export default function DashboardLayout({
 }: {
   children: React.ReactNode;
 }) {
-  return <div>{children}</div>;
+  return (
+    <div>
+      <nav>
+      </nav>
+      {children}
+    </div>
+  );
 }

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+//CAN YOU PLEASE MOVE THE DASHBOARD ACCESS LOGIC FOR FLASHCARDS_DASHBOARD INSTEAD?
 
 const Dashboard = () => {
   return <div>Dashboard</div>;

--- a/app/flashcards_dashboard/page.tsx
+++ b/app/flashcards_dashboard/page.tsx
@@ -1,32 +1,101 @@
-//this is the page where the user can come and see all the flashcards they have ever built
-'use client';
-import React, { useState } from 'react';
-import {useRouter} from 'next/navigation'
-
+//THIS IS THE ACUTAL DASHBOARD BECAUSE I COULD NOT GET THE OTHER ONE TO WORK SINCE I CANNOT USE CLERK
+"use client";
+import React, { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { app, db } from "../../firebase";
+import {
+  doc,
+  collection,
+  setDoc,
+  getFirestore,
+  getDocs,
+} from "firebase/firestore";
+import Link from "next/link";
+import Deck from "../components/Deck";
 export default function Dashboard() {
-  const [flashcards, setFlashcards] = useState([]);
-  const [flipped, setFlipped] = useState([]);
-  const [text, setText] = useState('');
-  const [name, setName] = useState('');
-  const [open, setOpen] = useState(false);
-
-
-  const handleCardClick = (id: any) => {
-    setFlipped((prev) => ({
-      ...prev,
-      [id]: !prev[id],
-    }));  
+  //just setting the type of the dek
+  type Deck = {
+    id: string;
   };
-  const handleOpen = () => {
-    setOpen(true);
-  }
-  const handleClose = () => {
-    setOpen(false);
-  }
+  const [decks, setDecks] = useState<Deck[]>([]);//store all decks
+  const [deck, setDeck] = useState<Deck | null>(null); //store an individual deck
+  const [cardsArray, setCardsArray] = useState<any[]>([]);//store the cards for a singular deck
+  const [cards, setCards] = useState<
+    Array<{ id: number; frontHTML: string; backHTML: string }>
+  >([]); //this is the array that goes into Deck.tsx for card rendering
+  const [loading, setLoading] = useState(true); //the loading component
+  //
+
+  //this is a function to select a deck upon clicking and then setting the cards
+  const selectDeck = (deck: any) => {
+    setDeck(deck);
+    setCardsArray(deck.cards);
+    console.log(`Selected deck: ${deck.id} and cards: ${deck.cards[0].front}`);
+    const cards: any = [];
+    cardsArray.forEach((card: any) => {
+      cards.push({
+        id: card.origin,
+        frontHTML: card.front,
+        backHTML: card.back,
+      });
+    });
+    setCards(cards);
+  };
+  //this is to load the different decks at the very beginning
+  useEffect(() => {
+    const getDecks = async () => {
+      //get all documents (the collection is named 'flashcards')
+      const querySnapshots = await getDocs(collection(db, "flashcards"));
+      //
+      const decksData: Deck[] = querySnapshots.docs.map((doc: any) => ({
+        id: doc.id,
+        ...doc.data(),
+      }));
+      setDecks(decksData);
+      setLoading(false);
+    };
+
+    getDecks();
+  }, []);
+
   return (
     <div>
-      <h1>Dashboard</h1>
-      <p>Welcome to the dashboard!</p>
+      <nav className="flex justify-between p-4 border border-2">
+        <div className="text-2xl font-bold">Flips</div>
+        <div>This is gonna be the user button</div>
+      </nav>
+      <div className="flex justify-end">
+      
+        <Link href="/upload_page"><p className="bg-white text-black font-bold">Create New Flashcards</p></Link>
+      
+        </div>
+      <div className="flex h-screen">
+        <div
+          className={`border border-2 w-1/3 ${loading ? "flex justify-center items-center" : ""}`}
+        >
+          {loading ? (
+            /* From Uiverse.io by yohohopizza */
+            <div className="flex flex-row gap-2">
+              <div className="w-4 h-4 rounded-full bg-white animate-bounce"></div>
+              <div className="w-4 h-4 rounded-full bg-white animate-bounce [animation-delay:-.3s]"></div>
+              <div className="w-4 h-4 rounded-full bg-white animate-bounce [animation-delay:-.5s]"></div>
+            </div>
+          ) : (
+            <ul>
+              {decks.map((deck) => (
+                <li key={deck.id} onClick={() => selectDeck(deck)}>
+                  <div className="w-full truncate bg-white p-2 text-black border border-2-white hover:bg-zinc-400">
+                    {deck.id}
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+        <div className="w-2/3 border border-2 flex justify-center items-center h-full">
+          <div>{deck && <Deck cards={cards} />}</div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -19,7 +19,7 @@ export default function RootLayout({
 }>) {
   return (
 
-    <ClerkProvider>
+    <ClerkProvider publishableKey={process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY}>
     <html lang="en">
       <body className={inter.className}>
 

--- a/app/upload_page/page.tsx
+++ b/app/upload_page/page.tsx
@@ -2,8 +2,8 @@ import DropZone from '../components/DropZone';
 
 const uploadPage = () => {
   return(
-    <div className="flex flex-col items-center justify-center h-screen">
-      <h1 className="text-3xl font-bold mb-4">Upload a PDF</h1>
+    <div className="flex flex-col items-center justify-center h-screen pt-6">
+      <h1 className="text-3xl font-bold mb-2">Upload a PDF</h1>
       <DropZone />
     </div>
   );

--- a/firebase.js
+++ b/firebase.js
@@ -20,4 +20,4 @@ const app = initializeApp(firebaseConfig);
 const storage = getStorage(app);
 const db = getFirestore(app);
 
-export { storage, db };
+export { storage, db, app };

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,7 @@
       "name": "quickcards",
       "version": "0.1.0",
       "dependencies": {
-
         "@clerk/nextjs": "^5.3.1",
-
         "@splinetool/react-spline": "^4.0.0",
         "@stripe/react-stripe-js": "^2.8.0",
         "@stripe/stripe-js": "^4.3.0",
@@ -7912,7 +7910,6 @@
         "node": ">=0.10.0"
       }
     },
-
     "node_modules/sprintf-js": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
@@ -7929,7 +7926,6 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
-
     "node_modules/std-env": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.7.0.tgz",


### PR DESCRIPTION
After accepting this, here are a few things to take into account

- the flashcards_dashboard route is the actual route for the dashboard. I could not use the regular dashboard route because of clerk but i think you can update that in the middleware
- Implementing redirects: the flow should go like this-> the user logs in-signs up -> directed to flashcards dashboard where they either choose to use their flashcards or they can create a new one with a button -> button redirects to upload_page component, and after uploading and creating the flashcards they can study them right there, but still have the option to go back to the dashboard where they will still find them anyway
- From my side I will actually start thinking harder about the actual design of upload and dashboard routes(an actual sketch so I do not do guesswork and the design is consistent across the entire app)
- Let’s get on a call tomorrow so we can talk about deets, we might need to code together in real time this time